### PR TITLE
Add tomcat8-nojsvc@.service systemd unit template

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ To start the service there are 2 different systemd services:
 - `tomcat8.service`: control a standard Tomcat instance, webapps should be placed under `/opt/tomcat8/webapps/`
 - `tomcat8@.service`: control multiple instances of the service, you must define `CATALINA_BASE` inside `/etc/sysconfig/tomcat8@<instance` file
   This service can be used to start applications previously installed under Tomcat 7 and hosted inside `/var/lib/tomcats` directory.
+- `tomcat8-nojsvc@.service`: same as `tomcat8@.service`, but this service don't use `jsvc` for launch the application, instead use `java` directly.
+  This approach make possible to use standard Java debug tools, but the application can't perform some privileged operations (e.g. bind to a port < 1024).
 
 

--- a/tomcat8-nojsvc@.service
+++ b/tomcat8-nojsvc@.service
@@ -1,0 +1,33 @@
+# Systemd unit file for tomcat instances.
+#
+# To create clones of this service:
+# 0. systemctl enable tomcat8-nojsvc@name.service
+# 1. create catalina.base directory structure in
+#    /var/lib/tomcats/name
+# 2. set catalina base inside /etc/sysconfig/tomcat8@<name>
+
+[Unit]
+Description=Apache Tomcat 8 Web Application Container (No Jsvc)
+After=syslog.target network.target
+
+[Service]
+Type=simple
+SuccessExitStatus=143
+
+Environment="NAME=%I"
+
+Environment=CATALINA_HOME=/opt/tomcat8
+Environment=JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+Environment='CATALINA_OPTS=-Xms512M -Xmx1024M -server -XX:+UseParallelGC -Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom'
+Environment=TOMCAT_USER=tomcat
+
+EnvironmentFile=-/etc/sysconfig/tomcat8@%I
+
+ExecStart=/opt/tomcat8/bin/catalina.sh run
+
+User=tomcat
+Group=tomcat
+UMask=0007
+
+[Install]
+WantedBy=multi-user.target

--- a/tomcat8.spec
+++ b/tomcat8.spec
@@ -7,6 +7,7 @@ URL: %{url_prefix}/%{name}
 Source0: http://it.apache.contactlab.it/tomcat/tomcat-8/v%{version}/bin/apache-tomcat-%{version}.tar.gz
 Source1: tomcat8.service
 Source2: tomcat8@.service
+Source3: tomcat8-nojsvc@.service
 BuildArch: noarch
 
 Requires: java-1.8.0-openjdk, apache-commons-daemon-jsvc
@@ -48,6 +49,7 @@ tar xvf  %{SOURCE0} -C %{buildroot}/opt/tomcat8 --strip-components=1
 mkdir -p %{buildroot}/usr/lib/systemd/system/
 cp %{SOURCE1} %{buildroot}/usr/lib/systemd/system/
 cp %{SOURCE2} %{buildroot}/usr/lib/systemd/system/
+cp %{SOURCE3} %{buildroot}/usr/lib/systemd/system/
 rm -rf %{buildroot}/opt/tomcat8/webapps/examples
 
 

--- a/tomcat8.spec
+++ b/tomcat8.spec
@@ -4,7 +4,7 @@ Version: 8.5.35
 Release: 1%{?dist}
 License: GPL
 URL: %{url_prefix}/%{name} 
-Source0: http://it.apache.contactlab.it/tomcat/tomcat-8/v%{version}/bin/apache-tomcat-%{version}.tar.gz
+Source0: https://archive.apache.org/dist/tomcat/tomcat-8/v%{version}/bin/apache-tomcat-%{version}.tar.gz
 Source1: tomcat8.service
 Source2: tomcat8@.service
 Source3: tomcat8-nojsvc@.service


### PR DESCRIPTION
Using `tomcat8-nojsvc@.service` unit template an application can be
started directly with `java`.
Using `java` enable the use of Java debug tools, but the application
can't do some privileged operations (e.g. bind to a port < 1024).