### PR TITLE
Use `java` directly for starting appications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ To start the service there are 2 different systemd services:
 - `tomcat8.service`: control a standard Tomcat instance, webapps should be placed under `/opt/tomcat8/webapps/`
 - `tomcat8@.service`: control multiple instances of the service, you must define `CATALINA_BASE` inside `/etc/sysconfig/tomcat8@<instance` file
   This service can be used to start applications previously installed under Tomcat 7 and hosted inside `/var/lib/tomcats` directory.
-- `tomcat8-nojsvc@.service`: same as `tomcat8@.service`, but this service don't use `jsvc` for launch the application, instead use `java` directly.
-  This approach make possible to use standard Java debug tools, but the application can't perform some privileged operations (e.g. bind to a port < 1024).
-
-
+- `tomcat8-jsvc@.service`: same as `tomcat8@.service`, but this service use `jsvc` for launch the application.
+  This approach make possible for application to perform some privileged operations (e.g. bind to a port < 1024), but make use of standard Java debug tools
+  more difficult.

--- a/tomcat8-jsvc@.service
+++ b/tomcat8-jsvc@.service
@@ -1,29 +1,31 @@
 # Systemd unit file for tomcat instances.
 #
 # To create clones of this service:
-# 0. systemctl enable tomcat8-nojsvc@name.service
+# 0. systemctl enable tomcat8-jsvc@name.service
 # 1. create catalina.base directory structure in
 #    /var/lib/tomcats/name
 # 2. set catalina base inside /etc/sysconfig/tomcat8@<name>
 
 [Unit]
-Description=Apache Tomcat 8 Web Application Container (No Jsvc)
+Description=Apache Tomcat 8 Web Application Container (Using Jsvc)
 After=syslog.target network.target
 
 [Service]
 Type=simple
-SuccessExitStatus=143
 
 Environment="NAME=%I"
 
 Environment=CATALINA_HOME=/opt/tomcat8
 Environment=JAVA_HOME=/usr/lib/jvm/jre-1.8.0
 Environment='CATALINA_OPTS=-Xms512M -Xmx1024M -server -XX:+UseParallelGC -Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom'
+Environment=CATALINA_PID=/opt/tomcat8/temp/tomcat-%I.pid
 Environment=TOMCAT_USER=tomcat
+Environment=JSVC=/usr/bin/jsvc
 
 EnvironmentFile=-/etc/sysconfig/tomcat8@%I
 
-ExecStart=/opt/tomcat8/bin/catalina.sh run
+ExecStart=/opt/tomcat8/bin/daemon.sh run
+ExecStop=/opt/tomcat8/bin/daemon.sh stop
 
 User=tomcat
 Group=tomcat

--- a/tomcat8.spec
+++ b/tomcat8.spec
@@ -7,7 +7,7 @@ URL: %{url_prefix}/%{name}
 Source0: https://archive.apache.org/dist/tomcat/tomcat-8/v%{version}/bin/apache-tomcat-%{version}.tar.gz
 Source1: tomcat8.service
 Source2: tomcat8@.service
-Source3: tomcat8-nojsvc@.service
+Source3: tomcat8-jsvc@.service
 BuildArch: noarch
 
 Requires: java-1.8.0-openjdk, apache-commons-daemon-jsvc

--- a/tomcat8@.service
+++ b/tomcat8@.service
@@ -1,5 +1,5 @@
 # Systemd unit file for tomcat instances.
-# 
+#
 # To create clones of this service:
 # 0. systemctl enable tomcat8@name.service
 # 1. create catalina.base directory structure in
@@ -12,20 +12,18 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
+SuccessExitStatus=143
 
 Environment="NAME=%I"
 
 Environment=CATALINA_HOME=/opt/tomcat8
 Environment=JAVA_HOME=/usr/lib/jvm/jre-1.8.0
 Environment='CATALINA_OPTS=-Xms512M -Xmx1024M -server -XX:+UseParallelGC -Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom'
-Environment=CATALINA_PID=/opt/tomcat8/temp/tomcat-%I.pid
 Environment=TOMCAT_USER=tomcat
-Environment=JSVC=/usr/bin/jsvc
 
 EnvironmentFile=-/etc/sysconfig/tomcat8@%I
 
-ExecStart=/opt/tomcat8/bin/daemon.sh run
-ExecStop=/opt/tomcat8/bin/daemon.sh stop
+ExecStart=/opt/tomcat8/bin/catalina.sh run
 
 User=tomcat
 Group=tomcat


### PR DESCRIPTION
Switch to `java` as default method for start tomcat application container,
applications that still need `jsvc`, can use the systemd `tomcat8-jsvc@.service`
unit template file.

NethServer/dev#5788